### PR TITLE
Update report import handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-config.yaml
 Pipfile.lock

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,8 @@
+# Example configuration for the import script
+instance_url: https://yourapp.plextrac.com
+username: your.username
+password: your.password
+cf_token:
+client_id: 1234
+ptrac_folder: ./ptrac_files
+rbac_role_payload:


### PR DESCRIPTION
## Summary
- combine client and report import logic into one
- iterate over `.ptrac` files in a configured folder
- add example `config.yaml`
- allow `config.yaml` to be tracked by git

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6865858571ec832697253aada4ed3c10