### PR TITLE
Fix workflow pipenv usage

### DIFF
--- a/.github/workflows/run-script.yaml
+++ b/.github/workflows/run-script.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install pipenv
-          pipenv install --system --deploy
+          pipenv install --deploy
 
       - name: Run script
         env:
@@ -45,4 +45,4 @@ jobs:
           USERNAME: ${{ github.event.inputs.username }}
           PASSWORD: ${{ github.event.inputs.password }}
         run: |
-          python main.py
+          pipenv run python main.py


### PR DESCRIPTION
## Summary
- adjust pipenv install step to avoid `--system` error
- run script via `pipenv run`

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_686eda1e71b88326aa0cda833e89e0b8